### PR TITLE
WDP200301-5

### DIFF
--- a/src/components/common/Button/Button.js
+++ b/src/components/common/Button/Button.js
@@ -3,7 +3,15 @@ import PropTypes from 'prop-types';
 
 import styles from './Button.module.scss';
 
-const Button = ({ children, variant, noHover, className: propClassName, ...props }) => {
+const Button = ({
+  children,
+  variant,
+  noHover,
+  favorite,
+  compare,
+  className: propClassName,
+  ...props
+}) => {
   const classes = [];
 
   if (propClassName) classes.push(propClassName);
@@ -18,6 +26,14 @@ const Button = ({ children, variant, noHover, className: propClassName, ...props
     Comp = 'div';
   }
 
+  if (favorite) {
+    classes.push(styles.favorite);
+  }
+
+  if (compare) {
+    classes.push(styles.compare);
+  }
+
   return (
     <Comp href='#' {...props} className={classes.join(' ')}>
       {children}
@@ -30,6 +46,8 @@ Button.propTypes = {
   noHover: PropTypes.bool,
   className: PropTypes.string,
   variant: PropTypes.string,
+  favorite: PropTypes.bool,
+  compare: PropTypes.bool,
 };
 
 export default Button;

--- a/src/components/common/Button/Button.module.scss
+++ b/src/components/common/Button/Button.module.scss
@@ -39,3 +39,13 @@
     color: #ffffff;
   }
 }
+
+.favorite {
+  background-color: $primary;
+  color: #ffffff;
+}
+
+.compare {
+  background-color: $primary;
+  color: #ffffff;
+}

--- a/src/components/common/ProductBox/ProductBox.js
+++ b/src/components/common/ProductBox/ProductBox.js
@@ -11,7 +11,7 @@ import {
 import { faStar as farStar, faHeart } from '@fortawesome/free-regular-svg-icons';
 import Button from '../Button/Button';
 
-const ProductBox = ({ name, price, promo, stars }) => (
+const ProductBox = ({ name, price, promo, stars, favorite, compare }) => (
   <div className={styles.root}>
     <div className={styles.photo}>
       {promo && <div className={styles.sale}>{promo}</div>}
@@ -39,10 +39,10 @@ const ProductBox = ({ name, price, promo, stars }) => (
     <div className={styles.line}></div>
     <div className={styles.actions}>
       <div className={styles.outlines}>
-        <Button variant='outline'>
+        <Button favorite={favorite} variant='outline'>
           <FontAwesomeIcon icon={faHeart}>Favorite</FontAwesomeIcon>
         </Button>
-        <Button variant='outline'>
+        <Button compare={compare} variant='outline'>
           <FontAwesomeIcon icon={faExchangeAlt}>Add to compare</FontAwesomeIcon>
         </Button>
       </div>
@@ -61,6 +61,8 @@ ProductBox.propTypes = {
   price: PropTypes.number,
   promo: PropTypes.string,
   stars: PropTypes.number,
+  favorite: PropTypes.bool,
+  compare: PropTypes.bool,
 };
 
 export default ProductBox;

--- a/src/redux/initialState.js
+++ b/src/redux/initialState.js
@@ -15,6 +15,8 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: true,
+      compare: true,
     },
     {
       id: 'aenean-ru-bristique-2',
@@ -24,6 +26,8 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: true,
+      compare: false,
     },
     {
       id: 'aenean-ru-bristique-3',
@@ -33,6 +37,8 @@ const initialState = {
       stars: 2,
       promo: 'sale',
       newFurniture: true,
+      favorite: false,
+      compare: true,
     },
     {
       id: 'aenean-ru-bristique-4',


### PR DESCRIPTION
### Opis problemu:
Brak ostylowania stanów "ulubiony" oraz "dodany do porównania" w karcie produktów

### Rozwiązanie:
- dodałem do stanu początkowego właściwości 'favorite' i 'compare' żeby w późniejszym etapie móc modyfikować ten stan i zapisywać go na serwerze,
- stan reduxowy pozwolił na przekazanie propsów bezpośrednio do komponentu ProductBox i wykorzystania ich w odpowiednich Buttonach,
- w komponencie Button dodałem warunki wykrywające obecność przekazanych propsów które dodały odpowiednie klasy do renderowanych komponentów 
- klasy odpowiadają odpowiednim stylom zmieniającym tło przycisków.