### PR TITLE
WDP200301-16

### DIFF
--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -5,6 +5,7 @@
   text-align: center;
   margin-top: 40px;
   display: block;
+  height: calc(100% - 40px);
 
   &:hover {
     text-decoration: none;

--- a/src/components/features/FeatureBoxes/FeatureBoxes.js
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.js
@@ -15,25 +15,25 @@ const FeatureBoxes = () => (
   <div className={styles.root}>
     <div className='container'>
       <div className='row'>
-        <div className='col'>
+        <div className={`col-6 col-lg-3 ${styles.featureBox}`}>
           <FeatureBox icon={faTruck}>
             <h5>Free shipping</h5>
             <p>All orders</p>
           </FeatureBox>
         </div>
-        <div className='col'>
+        <div className={`col-6 col-lg-3 ${styles.featureBox}`}>
           <FeatureBox icon={faHeadphones}>
             <h5>24/7 customer</h5>
             <p>support</p>
           </FeatureBox>
         </div>
-        <div className='col'>
+        <div className={`col-6 col-lg-3 ${styles.featureBox}`}>
           <FeatureBox icon={faReplyAll}>
             <h5>Money back</h5>
             <p>guarantee</p>
           </FeatureBox>
         </div>
-        <div className='col'>
+        <div className={`col-6 col-lg-3 ${styles.featureBox}`}>
           <FeatureBox icon={faBullhorn}>
             <h5>Member discount</h5>
             <p>First order</p>

--- a/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
@@ -3,3 +3,7 @@
 .root {
   padding: 5rem 0;
 }
+
+.featureBox {
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
### Opis problemu:
- Brak RWD w sekcji kart korzyści ("Free shipping", etc.).

- tablet i mobile ma mieć karty korzyści w 2 rzędach, po 2 elementy w każdym, ale elementy w jednym rzędzie (obok siebie) nie powinny się różnić wysokością

### Rozwiązanie:
- dodałem odpowiednie bootstrapowe klasy do kontenerów dla FeatureBox'ów
- dodałem wysokość dla roota w stylach FeatureBox (z odjęciem marginu)
- żeby była większa przestrzeń między 2 rzędami dodałem klasę z margin bottom 