### PR TITLE
Add variable for colors in styles

### DIFF
--- a/src/components/common/Button/Button.module.scss
+++ b/src/components/common/Button/Button.module.scss
@@ -4,15 +4,15 @@
 // }
 
 .main {
-  background-color: #2a2a2a;
-  color: #ffffff;
+  background-color: $button-main-bgc;
+  color: $button-main-color;
   font-size: 16px;
   line-height: 24px;
   font-weight: 600;
   padding: 10px 30px;
 
   &:not(.noHover):hover {
-    color: #ffffff !important;
+    color: $button-main-not-color !important;
     background-color: $primary;
     text-decoration: none;
   }
@@ -29,14 +29,14 @@
 .outline {
   display: inline-block;
   padding: 5px 10px;
-  border: 1px solid #2a2a2a;
-  color: #2a2a2a;
+  border: 1px solid $button-outline-border;
+  color: $button-outline-color;
   font-size: 13px;
   line-height: 22px;
 
   &:not(.noHover):hover {
-    background-color: #2a2a2a;
-    color: #ffffff;
+    background-color: $button-outline-border;
+    color: $button-outline-not-color;
   }
 }
 
@@ -49,10 +49,10 @@
 
 .favorite {
   background-color: $primary;
-  color: #ffffff;
+  color: $button-favorite-color;
 }
 
 .compare {
   background-color: $primary;
-  color: #ffffff;
+  color: $button-compare-color;
 }

--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -1,7 +1,7 @@
 @import "../../../styles/settings.scss";
 
 .root {
-  border: 1px solid #b6b6b6;
+  border: 1px solid $featureBox-root-border;
   text-align: center;
   margin-top: 40px;
   display: block;
@@ -10,7 +10,7 @@
     text-decoration: none;
 
     .iconWrapper {
-      color: #ffffff;
+      color: $featureBox-root-icon-color;
 
       &::after {
         background-color: $primary;
@@ -38,7 +38,7 @@
 
     &::before {
       content: "";
-      border: 1px solid #b6b6b6;
+      border: 1px solid $featureBox-icon-border;
       position: absolute;
       top: 50%;
       left: 50%;
@@ -46,7 +46,7 @@
       width: 76px;
       height: 76px;
       border-radius: 100%;
-      background-color: #ffffff;
+      background-color: $featureBox-icon-bgc;
       z-index: -1;
     }
 
@@ -59,13 +59,13 @@
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      border: 1px solid #b6b6b6;
+      border: 1px solid $featureBox-icon-border;
     }
   }
 
   .content {
     text-transform: uppercase;
-    color: rgb(42, 42, 42);
+    color: $featureBox-content-color;
     margin-top: -0.5rem;
     letter-spacing: 1px;
     font-weight: 300;

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -1,8 +1,8 @@
 @import "../../../styles/settings.scss";
 
 .root {
-  background-color: #ffffff;
-  border: 1px solid #e1e1e1;
+  background-color: $productBox-root-bgc;
+  border: 1px solid $productBox-root-border;
   margin-bottom: 2rem;
 
   &:hover {
@@ -19,7 +19,7 @@
     position: relative;
     padding: 80% 10px 0 10px;
     background: {
-      color: #f4f5f7;
+      color: $productBox-photo-color;
       size: contain;
       position: center;
       repeat: no-repeat;
@@ -32,9 +32,9 @@
       top: -30px;
       left: 50%;
       transform: translateX(-50%);
-      background-color: #292929;
+      background-color: $productBox-sale-bgc;
       border-radius: 50%;
-      color: #ffffff;
+      color: $productBox-sale-color;
       padding: 30px 15px 5px 15px;
     }
 
@@ -59,14 +59,14 @@
     .stars {
       a {
         text-decoration: none;
-        color: rgb(42, 42, 42);
+        color: $productBox-stars-color;
       }
     }
   }
 
   .line {
     margin: 0 10px;
-    border-bottom: 1px solid #2a2a2a;
+    border-bottom: 1px solid $productBox-line-border;
     position: relative;
 
     &::before {

--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -6,7 +6,7 @@
     position: relative;
 
     :global(.row) > * {
-      border-bottom: 4px solid #e2e2e2;
+      border-bottom: 4px solid $newFurniture-panelBar-border;
     }
 
     .heading {
@@ -43,7 +43,7 @@
           font-weight: 600;
 
           a {
-            color: rgb(42, 42, 42);
+            color: $newFurniture-menu-a;
             position: relative;
             text-decoration: none;
             font-size: 18px;
@@ -74,7 +74,7 @@
         margin: 0;
         padding: 0 0 0 1rem;
         list-style: none;
-        background-color: #ffffff;
+        background-color: $newFurniture-dots-bgc;
         transform: translateY(15px);
 
         li {
@@ -86,7 +86,7 @@
             width: 13px;
             height: 13px;
             border-radius: 6px;
-            background-color: #e1e1e1;
+            background-color: $newFurniture-dots-a;
             font-size: 0;
 
             &.active,

--- a/src/components/layout/CompanyClaim/CompanyClaim.module.scss
+++ b/src/components/layout/CompanyClaim/CompanyClaim.module.scss
@@ -12,7 +12,7 @@
       margin: 0;
       font-size: 17px;
       line-height: 42px;
-      color: rgb(216, 216, 216);
+      color: $companyClaim-phoneNumber-p;
       font-weight: 500;
 
       .icon {
@@ -29,7 +29,7 @@
     .cartBox {
       display: inline-block;
       position: relative;
-      color: #ffffff;
+      color: $companyClaim-cardBox-color;
 
       .cartIcon {
         background-color: $primary;
@@ -55,7 +55,7 @@
         align-items: center;
         justify-content: center;
         font-size: 14px;
-        color: rgb(224, 227, 237);
+        color: $companyClaim-cardCounter-color;
         position: absolute;
         top: 50%;
         right: 0;

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -7,7 +7,7 @@
 
     .menuWrapper {
       h6 {
-        color: #ffffff;
+        color: $footer-menu-h6;
         text-transform: uppercase;
         margin: 0 0 1rem 0;
       }
@@ -20,10 +20,10 @@
           a {
             font-size: 14px;
             line-height: 30px;
-            color: rgb(169, 169, 169);
+            color: $footer-menu-a;
 
             &:hover {
-              color: #ffffff;
+              color: $footer-menu-hover;
             }
           }
         }
@@ -51,7 +51,7 @@
     .copyright {
       p {
         margin: 0;
-        color: rgb(169, 169, 169);
+        color: $footer-copyright-p;
         font-size: 14px;
         line-height: 26px;
       }
@@ -68,7 +68,7 @@
           margin-left: 1rem;
 
           a {
-            color: rgb(169, 169, 169);
+            color: $footer-socialMedia-a;
             text-decoration: none;
 
             &:hover {

--- a/src/components/layout/MenuBar/MenuBar.module.scss
+++ b/src/components/layout/MenuBar/MenuBar.module.scss
@@ -2,7 +2,7 @@
 
 .root {
   box-shadow: 2px 3.464px 6px rgba(1, 2, 2, 0.2);
-  background-color: #ffffff;
+  background-color: $menuBar-root-bgc;
 
   :global(.container) > :global(.row) {
     height: 84px;
@@ -32,14 +32,14 @@
       text-decoration: none;
       display: flex;
       align-items: center;
-      border-top: 4px solid #ffffff;
+      border-top: 4px solid $menuBar-a-border;
       font-weight: 500;
       letter-spacing: 1px;
 
       &:hover,
       &.active {
         background-color: $primary;
-        color: #ffffff;
+        color: $menuBar-active-color;
         border-color: $primary;
       }
 

--- a/src/components/layout/TopBar/TopBar.module.scss
+++ b/src/components/layout/TopBar/TopBar.module.scss
@@ -13,7 +13,7 @@
       line-height: 55px;
 
       a {
-        color: #ffffff;
+        color: $header-topbar-a;
         font-size: 13px;
 
         &:hover {

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -1,14 +1,79 @@
+// VARIABLES WE DON NOT USE IN ANY ANOTHER FILES
+
+$darkGray: #2a2a2a;
+$veryDarkGray: #292929;
+$mediumDarkGray: #b6b6b6;
+$gray: #a5a5a5;
+$mediumGray: #a9a9a9;
+$lightGray: #d8d8d8;
+$mediumLightGray: #e2e2e2;
+$veryLightGray: #e1e1e1;
+$lightGrayishBlue: #e0e3ed;
+$mediumLightGrayishBlue: #f4f5f7;
+$battleshipGray: #434343;
+$shadow: #363636;
+
+$orange: #d58e32;
+$white: #ffffff;
+
+
+
+// VARIABLES WE ARE USING IN ANOTHER FILES
+$header-topbar-bg: $battleshipGray;
+$header-topbar-a: $white;
+$header-bg: $shadow;
+
+$newFurniture-panelBar-border: $mediumLightGray;
+$newFurniture-menu-a: $darkGray;
+$newFurniture-dots-bgc: $white;
+$newFurniture-dots-a: $veryLightGray;
+
+$companyClaim-phoneNumber-p: $lightGray;
+$companyClaim-cardCounter-color: $lightGrayishBlue;
+$companyClaim-cardBox-color: $white;
+
+$menuBar-active-color: $white;
+$menuBar-a-border: $white;
+$menuBar-root-bgc: $white;
+
+$footer-claim-bg: $darkGray;
+$footer-bg: $shadow;
+$footer-menu-h6: $white;
+$footer-menu-a: $mediumGray;
+$footer-menu-hover: $white;
+$footer-copyright-p: $mediumGray;
+$footer-socialMedia-a: $mediumGray;
+
+$productBox-root-bgc: $white;
+$productBox-root-border: $veryLightGray;
+$productBox-photo-color: $mediumLightGrayishBlue;
+$productBox-sale-bgc: $veryDarkGray;
+$productBox-sale-color: $white;
+$productBox-stars-color: $darkGray;
+$productBox-line-border: $darkGray;
+
+$featureBox-root-border: $mediumDarkGray;
+$featureBox-root-icon-color: $white;
+$featureBox-icon-border: $mediumDarkGray;
+$featureBox-icon-bgc: $white;
+$featureBox-content-color: $darkGray;
+
+$button-main-bgc: $darkGray;
+$button-main-color: $white;
+$button-main-not-color: $white;
+$button-main-not-color: $white;
+$button-outline-border: $darkGray;
+$button-outline-color: $darkGray;
+$button-outline-not-bgc: $darkGray;
+$button-outline-not-color: $white;
+$button-favorite-color: $white;
+$button-compare-color: $white;
+
+$primary: $orange;
+
+$text-color: $darkGray;
+$old-price-text-color: $gray;
+
+$form-border-color: $veryDarkGray;
+
 $base-padding: 24px;
-
-$header-topbar-bg: #434343;
-$header-bg: #363636;
-
-$footer-claim-bg: #2a2a2a;
-$footer-bg: #363636;
-
-$primary: #d58e32;
-
-$text-color: #2a2a2a;
-$old-price-text-color: #a5a5a5;
-
-$form-border-color: #292929;


### PR DESCRIPTION
**Opis problemu**


Część kolorów zdefiniowaliśmy jako zmienne w settingsach, ale potem chyba nigdzie nie zostały użyte. Poza tym w plikach styli komponentów znajduje się sporo innych kolorów. Musimy zrobić z tym porządek.

Robimy tak: w settingsach najpierw wrzucamy listę zmiennych z kolorami, np. "$darkGray: #2a2a2a", ale tych zmiennych nie używamy w żadnym innym pliku (trzeba dodać komentarz o tym wielkimi literami w tym pliku, a poza tym poinformować resztę zespołu).

Poniżej ustawiamy zmienne, które będą wykorzystywane w plikach komponentów i przypisujemy im zmienne z nazwami kolorów, czyli np. "$footer-claim-bg: $darkGray".

Dzięki temu klient będzie miał jeden plik w którym może sobie trochę pokombinować z kolorami, np. zmienić ciemno-szary kolor wszędzie na inny odcień, albo zmienić kolor claima w footerze z ciemno-szarego na ciemno-pomarańczowy, czy jakiś tam inny.

Rozwiązanie: 
-Stworzyłem zmienne dla każdego koloru. 
-Każdemu komponentowi dodałem zmienną z przypisanym kolorem.
-Komentarz z opisem, których zmiennych możemy używać w innych plikach, a których nie.