### PR TITLE
WDP200301-38

### DIFF
--- a/src/components/features/NewFurniture/NewFurniture.module.scss
+++ b/src/components/features/NewFurniture/NewFurniture.module.scss
@@ -48,6 +48,7 @@
             text-decoration: none;
             font-size: 18px;
             display: block;
+            cursor: pointer;
 
             &.active,
             &:hover {


### PR DESCRIPTION
### Opis problemu:
- po najechaniu na linki do podstron w sekcji "New furniture" (Bed, Chair itp...) pojawia się kursor zaznaczenia tekstu zamiast pointera linku

### Rozwiązanie:
- dodałem pointer dla linków w sekcji "New furniture" :)

*sorki za samowolkę - dodałem taska (buga) w Jirze i sam to zrobiłem ale nie mogłem patrzyć na ten kursor ;) (poćwiczyłem przynajmniej obsługę Jiry) ;)
*prawdopodobnie nie nadaje się to na 1pkt więc jak coś możemy uznać że to się nie liczy :P